### PR TITLE
Add Next.js dashboard skeleton

### DIFF
--- a/MANUFACTURING_DASHBOARD_GUIDE.md
+++ b/MANUFACTURING_DASHBOARD_GUIDE.md
@@ -1,0 +1,411 @@
+Manufacturing Dashboard Creation Guide
+Complete End-to-End Implementation Strategy
+
+## Phase 1: Architecture Foundation
+### Technology Stack Selection
+**Backend Database & API:**
+
+- **Primary:** Supabase (PostgreSQL with real-time features)
+- **Alternative:** PlanetScale (MySQL) + Prisma ORM
+- **Benefits:** Built-in auth, real-time subscriptions, edge functions
+
+**Frontend Framework:**
+
+- **Primary:** Next.js 14 (App Router)
+- **UI Library:** Shadcn/ui + Tailwind CSS
+- **Charts:** Recharts or Chart.js
+- **Real-time:** WebSockets or Server-Sent Events
+
+**Deployment:**
+
+- **Frontend:** Vercel (seamless Next.js deployment)
+- **Database:** Supabase hosted or self-hosted
+- **CI/CD:** GitHub Actions
+
+### Database Schema Design
+```sql
+-- Core Production Tables
+CREATE TABLE production_metrics (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp TIMESTAMPTZ NOT NULL,
+    machine_id VARCHAR(50),
+    operation_code VARCHAR(50),
+    pieces_produced INTEGER,
+    standard_hours DECIMAL(10,2),
+    actual_hours DECIMAL(10,2),
+    efficiency_percent DECIMAL(5,2),
+    downtime_hours DECIMAL(10,2),
+    scrap_count INTEGER,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Real-time Machine Status
+CREATE TABLE machine_status (
+    machine_id VARCHAR(50) PRIMARY KEY,
+    status VARCHAR(20), -- running, idle, maintenance, down
+    current_job VARCHAR(50),
+    last_update TIMESTAMPTZ DEFAULT NOW(),
+    utilization_percent DECIMAL(5,2)
+);
+
+-- Cost Tracking
+CREATE TABLE cost_metrics (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    date DATE NOT NULL,
+    material_cost DECIMAL(12,2),
+    labor_cost DECIMAL(12,2),
+    overhead_cost DECIMAL(12,2),
+    total_cost DECIMAL(12,2),
+    pieces_produced INTEGER,
+    cost_per_piece DECIMAL(10,4)
+);
+
+-- Quality Metrics
+CREATE TABLE quality_metrics (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp TIMESTAMPTZ NOT NULL,
+    product_number VARCHAR(50),
+    total_produced INTEGER,
+    defect_count INTEGER,
+    rework_count INTEGER,
+    scrap_count INTEGER,
+    first_pass_yield DECIMAL(5,2)
+);
+```
+
+## Phase 2: Data Integration Strategy
+### Option A: Direct Database Integration
+```javascript
+// lib/odyssey-connector.js
+import { createClient } from '@supabase/supabase-js'
+
+export class OdysseyDataSync {
+  constructor() {
+    this.supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY)
+  }
+
+  async syncProductionHistory() {
+    // Parse CSV files from your production history
+    const productionData = await this.parseProductionCSV()
+    
+    for (const record of productionData) {
+      await this.supabase.from('production_metrics').upsert({
+        timestamp: record.date,
+        machine_id: record.equipment,
+        operation_code: record.operation,
+        pieces_produced: record.quantity,
+        actual_hours: record.hours,
+        standard_hours: record.std_hours,
+        efficiency_percent: (record.std_hours / record.hours) * 100
+      })
+    }
+  }
+
+  async parseProductionCSV() {
+    // Implementation for parsing your production history CSVs
+    // This would read your productionhistyApril.csv, etc.
+  }
+}
+```
+
+### Option B: API Integration Layer
+```javascript
+// api/odyssey-sync/route.js
+import { NextResponse } from 'next/server'
+
+export async function POST(request) {
+  try {
+    const data = await request.json()
+    
+    // Transform Odyssey data format to your schema
+    const transformedData = transformOdysseyData(data)
+    
+    // Store in your database
+    await storeMetrics(transformedData)
+    
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 })
+  }
+}
+
+function transformOdysseyData(odysseyData) {
+  return odysseyData.map(record => ({
+    timestamp: new Date(record.Date),
+    machine_id: record.Equipment,
+    pieces_produced: parseInt(record.Quantity),
+    // ... other transformations
+  }))
+}
+```
+
+## Phase 3: Dashboard Components
+### Key Performance Indicators (KPIs)
+```javascript
+// components/KPICard.jsx
+export function KPICard({ title, value, trend, icon: Icon }) {
+  return (
+    <div className="bg-white p-6 rounded-lg shadow-sm border">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm font-medium text-gray-600">{title}</p>
+          <p className="text-2xl font-bold text-gray-900">{value}</p>
+        </div>
+        <Icon className="h-8 w-8 text-blue-600" />
+      </div>
+      <div className={`mt-2 text-sm ${trend >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+        {trend >= 0 ? '↗' : '↘'} {Math.abs(trend)}% from last period
+      </div>
+    </div>
+  )
+}
+```
+
+### Real-time Production Monitor
+```javascript
+// components/ProductionMonitor.jsx
+import { useEffect, useState } from 'react'
+import { supabase } from '@/lib/supabase'
+
+export function ProductionMonitor() {
+  const [machineData, setMachineData] = useState([])
+
+  useEffect(() => {
+    // Subscribe to real-time updates
+    const subscription = supabase
+      .channel('machine_status')
+      .on('postgres_changes', {
+        event: '*',
+        schema: 'public',
+        table: 'machine_status'
+      }, (payload) => {
+        setMachineData(prev => 
+          prev.map(machine => 
+            machine.machine_id === payload.new.machine_id 
+              ? payload.new 
+              : machine
+          )
+        )
+      })
+      .subscribe()
+
+    return () => subscription.unsubscribe()
+  }, [])
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {machineData.map(machine => (
+        <MachineCard key={machine.machine_id} machine={machine} />
+      ))}
+    </div>
+  )
+}
+```
+
+## Phase 4: Actionable Metrics Implementation
+### Manufacturing Efficiency Dashboard
+```javascript
+// pages/dashboard.js
+export default function Dashboard() {
+  const [metrics, setMetrics] = useState({
+    oee: 0,
+    scrapRate: 0,
+    onTimeDelivery: 0,
+    costPerPiece: 0
+  })
+
+  return (
+    <div className="space-y-6">
+      {/* KPI Overview */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+        <KPICard 
+          title="Overall Equipment Effectiveness" 
+          value={`${metrics.oee}%`}
+          trend={5.2}
+          icon={BarChart3}
+        />
+        <KPICard 
+          title="Scrap Rate" 
+          value={`${metrics.scrapRate}%`}
+          trend={-2.1}
+          icon={AlertTriangle}
+        />
+        {/* More KPIs */}
+      </div>
+
+      {/* Production Charts */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <ProductionEfficiencyChart />
+        <MachineUtilizationChart />
+      </div>
+
+      {/* Real-time Machine Status */}
+      <ProductionMonitor />
+    </div>
+  )
+}
+```
+
+## Phase 5: Custom Metric Builder
+### Dynamic Query Builder
+```javascript
+// components/MetricBuilder.jsx
+export function MetricBuilder() {
+  const [metric, setMetric] = useState({
+    name: '',
+    query: '',
+    visualization: 'line',
+    refreshInterval: 300
+  })
+
+  const buildQuery = () => {
+    // Visual query builder that generates SQL
+    return `
+      SELECT 
+        DATE_TRUNC('hour', timestamp) as period,
+        ${metric.aggregation}(${metric.field}) as value
+      FROM ${metric.table}
+      WHERE timestamp >= NOW() - INTERVAL '${metric.timeRange}'
+      GROUP BY period
+      ORDER BY period
+    `
+  }
+
+  return (
+    <div className="bg-white p-6 rounded-lg border">
+      <h3 className="text-lg font-semibold mb-4">Create Custom Metric</h3>
+      
+      <div className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium mb-2">Metric Name</label>
+          <input 
+            type="text"
+            value={metric.name}
+            onChange={(e) => setMetric({...metric, name: e.target.value})}
+            className="w-full p-2 border rounded"
+          />
+        </div>
+        
+        {/* Query builder interface */}
+        <MetricQueryBuilder metric={metric} setMetric={setMetric} />
+        
+        <button 
+          onClick={saveMetric}
+          className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
+        >
+          Save Metric
+        </button>
+      </div>
+    </div>
+  )
+}
+```
+
+## Phase 6: Deployment & CI/CD Setup
+### Repository Structure
+```
+manufacturing-dashboard/
+├── .github/
+│   └── workflows/
+│       └── deploy.yml
+├── components/
+│   ├── ui/
+│   ├── charts/
+│   └── dashboard/
+├── lib/
+│   ├── supabase.js
+│   ├── odyssey-connector.js
+│   └── utils.js
+├── pages/
+│   ├── api/
+│   └── dashboard/
+├── styles/
+├── public/
+├── package.json
+└── next.config.js
+```
+
+### GitHub Actions Workflow
+```yaml
+# .github/workflows/deploy.yml
+name: Deploy to Vercel
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '18'
+          
+      - name: Install dependencies
+        run: npm ci
+        
+      - name: Run tests
+        run: npm test
+        
+      - name: Deploy to Vercel
+        uses: vercel/action@v20
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.ORG_ID }}
+          vercel-project-id: ${{ secrets.PROJECT_ID }}
+```
+
+## Phase 7: Advanced Features
+### Predictive Analytics Integration
+```javascript
+// lib/predictive-analytics.js
+export class PredictiveAnalytics {
+  async predictMaintenance(machineId) {
+    const historicalData = await this.getMaintenanceHistory(machineId)
+    
+    // Simple predictive model based on usage patterns
+    const avgCyclesBetweenMaintenance = this.calculateAverage(historicalData)
+    const currentCycles = await this.getCurrentCycles(machineId)
+    
+    return {
+      nextMaintenanceDate: this.calculateNextMaintenance(currentCycles, avgCyclesBetweenMaintenance),
+      confidence: this.calculateConfidence(historicalData)
+    }
+  }
+
+  async optimizeProductionSchedule() {
+    // Production optimization algorithms
+  }
+}
+```
+
+### Alert System
+```javascript
+// lib/alerts.js
+export class AlertSystem {
+  async checkThresholds() {
+    const alerts = []
+    
+    // Check efficiency thresholds
+    const lowEfficiencyMachines = await this.findLowEfficiencyMachines()
+    alerts.push(...lowEfficiencyMachines.map(machine => ({
+      type: 'efficiency',
+      severity: 'warning',
+      message: `Machine ${machine.id} efficiency below 70%`,
+      actionRequired: 'Schedule maintenance check'
+    })))
+    
+    // Check quality thresholds
+    const qualityIssues = await this.findQualityIssues()
+    alerts.push(...qualityIssues)
+    
+    return alerts
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# schoenwetterandsons
+# Schoenwetter & Sons Manufacturing Dashboard
+
+This repository contains a basic Next.js dashboard that can be connected to your Supabase instance to visualize manufacturing metrics.
+
+## Getting Started
+
+1. Install Node.js 18 and npm.
+2. From the `dashboard-app` folder run `npm install` to install dependencies.
+3. Create a `.env.local` file in `dashboard-app` with the following variables:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_KEY=your-supabase-key
+```
+
+4. Run the development server:
+
+```bash
+npm run dev
+```
+
+The app will be available at `http://localhost:3000`.
+
+## Deployment
+
+- The app is ready to be deployed to Vercel. Create the environment variables in Vercel and connect this repository.
+- A sample GitHub Actions workflow can be created under `.github/workflows` to automate deployment.
+
+## Additional Tasks
+
+- Set up the database schema described in `MANUFACTURING_DASHBOARD_GUIDE.md` on your Supabase project.
+- Implement the `parseProductionCSV` function in `dashboard-app/lib/odyssey-connector.js` to import your production data.
+- Customize KPI calculations and charts according to your metrics.
+
+For a detailed step-by-step guide, see [MANUFACTURING_DASHBOARD_GUIDE.md](./MANUFACTURING_DASHBOARD_GUIDE.md).

--- a/dashboard-app/app/api/odyssey-sync/route.js
+++ b/dashboard-app/app/api/odyssey-sync/route.js
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '../../../lib/supabase'
+
+export async function POST(request) {
+  try {
+    const data = await request.json()
+    const records = transformOdysseyData(data)
+    await supabase.from('production_metrics').insert(records)
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    return NextResponse.json({ error: err.message }, { status: 500 })
+  }
+}
+
+function transformOdysseyData(list) {
+  return list.map(r => ({
+    timestamp: new Date(r.Date),
+    machine_id: r.Equipment,
+    pieces_produced: parseInt(r.Quantity, 10)
+  }))
+}

--- a/dashboard-app/app/globals.css
+++ b/dashboard-app/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/dashboard-app/app/layout.jsx
+++ b/dashboard-app/app/layout.jsx
@@ -1,0 +1,9 @@
+import './globals.css'
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50">{children}</body>
+    </html>
+  )
+}

--- a/dashboard-app/app/page.jsx
+++ b/dashboard-app/app/page.jsx
@@ -1,0 +1,5 @@
+import Dashboard from '../components/Dashboard'
+
+export default function Home() {
+  return <Dashboard />
+}

--- a/dashboard-app/components/Dashboard.jsx
+++ b/dashboard-app/components/Dashboard.jsx
@@ -1,0 +1,24 @@
+'use client'
+import { useState } from 'react'
+import KPICard from './KPICard'
+import ProductionEfficiencyChart from './ProductionEfficiencyChart'
+import MachineUtilizationChart from './MachineUtilizationChart'
+import ProductionMonitor from './ProductionMonitor'
+import { BarChart3, AlertTriangle } from 'lucide-react'
+
+export default function Dashboard() {
+  const [metrics] = useState({ oee: 0, scrapRate: 0 })
+  return (
+    <div className="space-y-6 p-4">
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        <KPICard title="OEE" value={`${metrics.oee}%`} trend={5.2} icon={BarChart3} />
+        <KPICard title="Scrap Rate" value={`${metrics.scrapRate}%`} trend={-2.1} icon={AlertTriangle} />
+      </div>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <ProductionEfficiencyChart />
+        <MachineUtilizationChart />
+      </div>
+      <ProductionMonitor />
+    </div>
+  )
+}

--- a/dashboard-app/components/KPICard.jsx
+++ b/dashboard-app/components/KPICard.jsx
@@ -1,0 +1,16 @@
+export default function KPICard({ title, value, trend, icon: Icon }) {
+  return (
+    <div className="bg-white p-4 rounded shadow border">
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="text-sm text-gray-600">{title}</p>
+          <p className="text-2xl font-bold">{value}</p>
+        </div>
+        {Icon && <Icon className="h-6 w-6 text-blue-600" />}
+      </div>
+      <div className={`mt-1 text-sm ${trend >= 0 ? 'text-green-600' : 'text-red-600'}`}> 
+        {trend >= 0 ? '↗' : '↘'} {Math.abs(trend)}%
+      </div>
+    </div>
+  )
+}

--- a/dashboard-app/components/MachineCard.jsx
+++ b/dashboard-app/components/MachineCard.jsx
@@ -1,0 +1,10 @@
+export default function MachineCard({ machine }) {
+  return (
+    <div className="border p-4 rounded bg-white shadow">
+      <h4 className="font-semibold mb-1">{machine.machine_id}</h4>
+      <p className="text-sm">Status: {machine.status}</p>
+      <p className="text-sm">Current Job: {machine.current_job}</p>
+      <p className="text-sm">Utilization: {machine.utilization_percent}%</p>
+    </div>
+  )
+}

--- a/dashboard-app/components/MachineUtilizationChart.jsx
+++ b/dashboard-app/components/MachineUtilizationChart.jsx
@@ -1,0 +1,14 @@
+'use client'
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
+
+export default function MachineUtilizationChart({ data = [] }) {
+  return (
+    <BarChart width={300} height={200} data={data}>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="machine" />
+      <YAxis />
+      <Tooltip />
+      <Bar dataKey="utilization" fill="#82ca9d" />
+    </BarChart>
+  )
+}

--- a/dashboard-app/components/ProductionEfficiencyChart.jsx
+++ b/dashboard-app/components/ProductionEfficiencyChart.jsx
@@ -1,0 +1,14 @@
+'use client'
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip } from 'recharts'
+
+export default function ProductionEfficiencyChart({ data = [] }) {
+  return (
+    <LineChart width={300} height={200} data={data}>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey="period" />
+      <YAxis />
+      <Tooltip />
+      <Line type="monotone" dataKey="value" stroke="#8884d8" />
+    </LineChart>
+  )
+}

--- a/dashboard-app/components/ProductionMonitor.jsx
+++ b/dashboard-app/components/ProductionMonitor.jsx
@@ -1,0 +1,36 @@
+'use client'
+import { useEffect, useState } from 'react'
+import { supabase } from '../lib/supabase'
+import MachineCard from './MachineCard'
+
+export default function ProductionMonitor() {
+  const [machines, setMachines] = useState([])
+
+  useEffect(() => {
+    const subscription = supabase
+      .channel('machine_status')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'machine_status' }, payload => {
+        setMachines(prev => {
+          const index = prev.findIndex(m => m.machine_id === payload.new.machine_id)
+          if (index !== -1) {
+            const copy = [...prev]
+            copy[index] = payload.new
+            return copy
+          }
+          return [...prev, payload.new]
+        })
+      })
+      .subscribe()
+    return () => {
+      subscription.unsubscribe()
+    }
+  }, [])
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {machines.map(m => (
+        <MachineCard key={m.machine_id} machine={m} />
+      ))}
+    </div>
+  )
+}

--- a/dashboard-app/lib/alerts.js
+++ b/dashboard-app/lib/alerts.js
@@ -1,0 +1,20 @@
+export class AlertSystem {
+  async checkThresholds() {
+    const alerts = []
+    const lowEfficiencyMachines = await this.findLowEfficiencyMachines()
+    alerts.push(...lowEfficiencyMachines.map(machine => ({
+      type: 'efficiency',
+      severity: 'warning',
+      message: `Machine ${machine.id} efficiency below 70%`,
+      actionRequired: 'Schedule maintenance check'
+    })))
+
+    const qualityIssues = await this.findQualityIssues()
+    alerts.push(...qualityIssues)
+
+    return alerts
+  }
+
+  async findLowEfficiencyMachines() { return [] }
+  async findQualityIssues() { return [] }
+}

--- a/dashboard-app/lib/odyssey-connector.js
+++ b/dashboard-app/lib/odyssey-connector.js
@@ -1,0 +1,28 @@
+import { createClient } from '@supabase/supabase-js'
+
+export class OdysseyDataSync {
+  constructor() {
+    this.supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.NEXT_PUBLIC_SUPABASE_KEY)
+  }
+
+  async syncProductionHistory() {
+    const productionData = await this.parseProductionCSV()
+
+    for (const record of productionData) {
+      await this.supabase.from('production_metrics').upsert({
+        timestamp: record.date,
+        machine_id: record.equipment,
+        operation_code: record.operation,
+        pieces_produced: record.quantity,
+        actual_hours: record.hours,
+        standard_hours: record.std_hours,
+        efficiency_percent: (record.std_hours / record.hours) * 100
+      })
+    }
+  }
+
+  async parseProductionCSV() {
+    // TODO: implement CSV parsing
+    return []
+  }
+}

--- a/dashboard-app/lib/predictive-analytics.js
+++ b/dashboard-app/lib/predictive-analytics.js
@@ -1,0 +1,21 @@
+export class PredictiveAnalytics {
+  async predictMaintenance(machineId) {
+    const historicalData = await this.getMaintenanceHistory(machineId)
+    const avgCyclesBetweenMaintenance = this.calculateAverage(historicalData)
+    const currentCycles = await this.getCurrentCycles(machineId)
+
+    return {
+      nextMaintenanceDate: this.calculateNextMaintenance(currentCycles, avgCyclesBetweenMaintenance),
+      confidence: this.calculateConfidence(historicalData)
+    }
+  }
+
+  // Placeholder methods
+  async getMaintenanceHistory() {
+    return []
+  }
+  calculateAverage() {}
+  async getCurrentCycles() {}
+  calculateNextMaintenance() {}
+  calculateConfidence() {}
+}

--- a/dashboard-app/lib/supabase.js
+++ b/dashboard-app/lib/supabase.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_KEY
+
+export const supabase = createClient(supabaseUrl, supabaseKey)

--- a/dashboard-app/next.config.js
+++ b/dashboard-app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/dashboard-app/package.json
+++ b/dashboard-app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "manufacturing-dashboard",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@supabase/supabase-js": "^2.38.1",
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "lucide-react": "^0.299.0"
+  },
+  "devDependencies": {
+    "eslint": "8.53.0",
+    "eslint-config-next": "14.0.0"
+  }
+}

--- a/dashboard-app/postcss.config.js
+++ b/dashboard-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/dashboard-app/tailwind.config.js
+++ b/dashboard-app/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- set up basic Next.js dashboard in `dashboard-app`
- add components for KPIs, charts, and production monitor
- add Supabase connector utilities
- rewrite README with setup instructions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ac12db314832abe64491bcd3d7407